### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/AzDevOpsEssential/b1ee0f18-0c83-42f7-8f50-04142587f43c/d2f26930-25af-4dfa-9acd-550452d8ed0a/_apis/work/boardbadge/969ba991-a0df-4c90-8ce8-4d4277c4baab)](https://dev.azure.com/AzDevOpsEssential/b1ee0f18-0c83-42f7-8f50-04142587f43c/_boards/board/t/d2f26930-25af-4dfa-9acd-550452d8ed0a/Microsoft.RequirementCategory)
 # GitHub for Developers
 
 - Class Date: THIS-DATE


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#420](https://dev.azure.com/AzDevOpsEssential/b1ee0f18-0c83-42f7-8f50-04142587f43c/_workitems/edit/420). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.